### PR TITLE
ジョーク記事へのリンクは混乱を招くため消去するべき

### DIFF
--- a/packages/textlint-rule-no-kana-english-v/README.md
+++ b/packages/textlint-rule-no-kana-english-v/README.md
@@ -74,7 +74,6 @@ Example:
 
 ## References
 
-- [『WIRED』日本版、ついに「ヴ」を廃止──新たに「ヷ」「ヸ」「ヹ」「ヺ」を採用へ｜WIRED.jp](https://wired.jp/2019/04/01/aprilfool-2019/)
 - [国名表記「ヴ」消える　変更法案、衆院で可決　　:日本経済新聞](https://www.nikkei.com/article/DGXMZO42662930Z10C19A3PP8000/)
 
 ## Changelog


### PR DESCRIPTION
校正ルールを説明、補足するべきのReadme内のRefarencesに挙げられているリンクの1つがジョーク記事へのURLになっています。 ジョーク記事の内容は事実ではなく、Refarenceに不適切であり、読者を混乱させるため、Refarencesの一部を削除しました。